### PR TITLE
Add documentation badge to README (Resolves #26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![Tests](https://github.com/GiggleLiu/BPDecoderPlus/actions/workflows/test.yml/badge.svg)](https://github.com/GiggleLiu/BPDecoderPlus/actions/workflows/test.yml)
 [![codecov](https://codecov.io/gh/GiggleLiu/BPDecoderPlus/branch/main/graph/badge.svg)](https://codecov.io/gh/GiggleLiu/BPDecoderPlus)
+[![Documentation](https://img.shields.io/badge/docs-online-blue.svg)](https://giggleliu.github.io/BPDecoderPlus/)
 
 A winter school project on circuit-level decoding of surface codes using belief propagation and integer programming decoders, with extensions for atom loss in neutral atom quantum computers.
 


### PR DESCRIPTION
## Summary

- Added a documentation badge to README.md linking to the deployed GitHub Pages documentation
- GitHub Pages is already configured and deployed at https://giggleliu.github.io/BPDecoderPlus/
- The documentation deployment workflow (`.github/workflows/docs.yml`) is already in place and working

## Changes

- Added documentation badge after the codecov badge in README.md
- Badge links to https://giggleliu.github.io/BPDecoderPlus/

## Resolves

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)