### PR TITLE
Fix GitHub Pages 404 error by updating deployment workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,10 +7,19 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
   deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -24,5 +33,17 @@ jobs:
         run: |
           pip install mkdocs-material mkdocstrings[python] pymdown-extensions
 
+      - name: Build documentation
+        run: mkdocs build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'site'
+
       - name: Deploy to GitHub Pages
-        run: mkdocs gh-deploy --force
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

Fixes the 404 error on the documentation site (https://giggleliu.github.io/BPDecoderPlus/) by modernizing the GitHub Pages deployment workflow.

## Problem

The previous workflow used `mkdocs gh-deploy --force` which:
1. Built the docs locally
2. Pushed to `gh-pages` branch using git

However, this approach had configuration issues with GitHub Pages resulting in 404 errors.

## Solution

Updated the workflow to use the modern GitHub Pages deployment approach:

1. **Build the documentation**: Run `mkdocs build` to generate the site
2. **Upload as artifact**: Use `actions/upload-pages-artifact@v3` to upload the built site
3. **Deploy with official action**: Use `actions/deploy-pages@v4` for deployment

Also updated:
- ✅ Added proper permissions (`pages: write`, `id-token: write`)
- ✅ Added `github-pages` environment configuration
- ✅ Added concurrency control to prevent deployment conflicts
- ✅ Updated GitHub Pages settings to use the correct source

## Testing

After merging this PR, the documentation will be automatically deployed and should be accessible at https://giggleliu.github.io/BPDecoderPlus/

## References

- [GitHub Pages deployment documentation](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site)
- [actions/deploy-pages](https://github.com/actions/deploy-pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)