### PR TITLE
Update repository organization from GiggleLiu to TensorBFS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Thank you for your interest in contributing to BPDecoderPlus! This document prov
 
 ```bash
 # Clone the repository
-git clone https://github.com/GiggleLiu/BPDecoderPlus.git
+git clone https://github.com/TensorBFS/BPDecoderPlus.git
 cd BPDecoderPlus
 
 # Install dependencies with uv (recommended)
@@ -257,9 +257,9 @@ Please include:
 
 ## Getting Help
 
-- **Issues**: [GitHub Issues](https://github.com/GiggleLiu/BPDecoderPlus/issues)
+- **Issues**: [GitHub Issues](https://github.com/TensorBFS/BPDecoderPlus/issues)
 - **Discussions**: Use GitHub Discussions for questions
-- **Documentation**: [Online Docs](https://giggleliu.github.io/BPDecoderPlus/)
+- **Documentation**: [Online Docs](https://tensorbfs.github.io/BPDecoderPlus/)
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # BPDecoderPlus: Quantum Error Correction with Belief Propagation
 
-[![Tests](https://github.com/GiggleLiu/BPDecoderPlus/actions/workflows/test.yml/badge.svg)](https://github.com/GiggleLiu/BPDecoderPlus/actions/workflows/test.yml)
-[![codecov](https://codecov.io/gh/GiggleLiu/BPDecoderPlus/branch/main/graph/badge.svg)](https://codecov.io/gh/GiggleLiu/BPDecoderPlus)
-[![Documentation](https://img.shields.io/badge/docs-online-blue.svg)](https://giggleliu.github.io/BPDecoderPlus/)
+[![Tests](https://github.com/TensorBFS/BPDecoderPlus/actions/workflows/test.yml/badge.svg)](https://github.com/TensorBFS/BPDecoderPlus/actions/workflows/test.yml)
+[![codecov](https://codecov.io/gh/TensorBFS/BPDecoderPlus/branch/main/graph/badge.svg)](https://codecov.io/gh/TensorBFS/BPDecoderPlus)
+[![Documentation](https://img.shields.io/badge/docs-online-blue.svg)](https://tensorbfs.github.io/BPDecoderPlus/)
 [![Python](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
@@ -118,7 +118,7 @@ Before starting, please read these foundational papers:
 uv pip install bpdecoderplus
 
 # For development
-git clone https://github.com/GiggleLiu/BPDecoderPlus.git
+git clone https://github.com/TensorBFS/BPDecoderPlus.git
 cd BPDecoderPlus
 uv sync --dev
 ```
@@ -127,7 +127,7 @@ uv sync --dev
 
 ```bash
 # Install from source
-git clone https://github.com/GiggleLiu/BPDecoderPlus.git
+git clone https://github.com/TensorBFS/BPDecoderPlus.git
 cd BPDecoderPlus
 pip install -e .[dev,docs]
 ```
@@ -266,7 +266,7 @@ make docs
 
 ```bash
 # Clone repository
-git clone https://github.com/GiggleLiu/BPDecoderPlus.git
+git clone https://github.com/TensorBFS/BPDecoderPlus.git
 cd BPDecoderPlus
 
 # Install with development dependencies
@@ -294,7 +294,7 @@ This project uses:
 ### Documentation
 - [Stim Documentation](https://github.com/quantumlib/Stim/blob/main/doc/index.md)
 - [Error Correction Zoo](https://errorcorrectionzoo.org/)
-- [BPDecoderPlus Documentation](https://giggleliu.github.io/BPDecoderPlus/)
+- [BPDecoderPlus Documentation](https://tensorbfs.github.io/BPDecoderPlus/)
 
 ## Troubleshooting
 
@@ -332,7 +332,7 @@ If you use BPDecoderPlus in your research, please cite:
   title = {BPDecoderPlus: Belief Propagation Decoders for Surface Codes},
   author = {Liu, Jinguo and Contributors},
   year = {2025},
-  url = {https://github.com/GiggleLiu/BPDecoderPlus}
+  url = {https://github.com/TensorBFS/BPDecoderPlus}
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 # BPDecoderPlus
 
-[![Tests](https://github.com/GiggleLiu/BPDecoderPlus/actions/workflows/test.yml/badge.svg)](https://github.com/GiggleLiu/BPDecoderPlus/actions/workflows/test.yml)
-[![codecov](https://codecov.io/gh/GiggleLiu/BPDecoderPlus/branch/main/graph/badge.svg)](https://codecov.io/gh/GiggleLiu/BPDecoderPlus)
+[![Tests](https://github.com/TensorBFS/BPDecoderPlus/actions/workflows/test.yml/badge.svg)](https://github.com/TensorBFS/BPDecoderPlus/actions/workflows/test.yml)
+[![codecov](https://codecov.io/gh/TensorBFS/BPDecoderPlus/branch/main/graph/badge.svg)](https://codecov.io/gh/TensorBFS/BPDecoderPlus)
 
 **Quantum Error Correction with Belief Propagation**
 
@@ -42,7 +42,7 @@ Install the package:
 
 ```bash
 # Clone the repository
-git clone https://github.com/GiggleLiu/BPDecoderPlus.git
+git clone https://github.com/TensorBFS/BPDecoderPlus.git
 cd BPDecoderPlus
 
 # Install dependencies

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
 site_name: BPDecoderPlus Documentation
 site_description: Quantum Error Correction with Belief Propagation
 site_author: BPDecoderPlus Contributors
-repo_url: https://github.com/GiggleLiu/BPDecoderPlus
-repo_name: GiggleLiu/BPDecoderPlus
+repo_url: https://github.com/TensorBFS/BPDecoderPlus
+repo_name: TensorBFS/BPDecoderPlus
 
 theme:
   name: material

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,11 +30,11 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/GiggleLiu/BPDecoderPlus"
-Documentation = "https://giggleliu.github.io/BPDecoderPlus/"
-Repository = "https://github.com/GiggleLiu/BPDecoderPlus"
-Issues = "https://github.com/GiggleLiu/BPDecoderPlus/issues"
-Changelog = "https://github.com/GiggleLiu/BPDecoderPlus/blob/main/CHANGELOG.md"
+Homepage = "https://github.com/TensorBFS/BPDecoderPlus"
+Documentation = "https://tensorbfs.github.io/BPDecoderPlus/"
+Repository = "https://github.com/TensorBFS/BPDecoderPlus"
+Issues = "https://github.com/TensorBFS/BPDecoderPlus/issues"
+Changelog = "https://github.com/TensorBFS/BPDecoderPlus/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
## Summary
- Updated all repository URLs from `github.com/GiggleLiu/BPDecoderPlus` to `github.com/TensorBFS/BPDecoderPlus`
- Updated documentation URLs from `giggleliu.github.io/BPDecoderPlus/` to `tensorbfs.github.io/BPDecoderPlus/`
- Updated all badges and links in README, documentation, and configuration files

## Files Changed
- `CONTRIBUTING.md` - Clone URL and help links
- `README.md` - Badges, clone URLs, documentation links, and citation
- `docs/index.md` - Badges and clone URL
- `pyproject.toml` - All project URLs (Homepage, Documentation, Repository, Issues, Changelog)
- `mkdocs.yml` - Repository URL and name

## Test plan
- [x] Verified all references to GiggleLiu have been replaced
- [ ] Verify documentation builds correctly after merge
- [ ] Verify badges work with new URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)